### PR TITLE
clippy: fix warnings from useless_vec lint

### DIFF
--- a/src/context_diff.rs
+++ b/src/context_diff.rs
@@ -703,9 +703,9 @@ mod tests {
     #[test]
     fn test_stop_early() {
         let from_filename = "foo";
-        let from = vec!["a", "b", "c", ""].join("\n");
+        let from = ["a", "b", "c", ""].join("\n");
         let to_filename = "bar";
-        let to = vec!["a", "d", "c", ""].join("\n");
+        let to = ["a", "d", "c", ""].join("\n");
         let context_size: usize = 3;
 
         let diff_full = diff(
@@ -716,7 +716,7 @@ mod tests {
             context_size,
             false,
         );
-        let expected_full = vec![
+        let expected_full = [
             "*** foo\t",
             "--- bar\t",
             "***************",
@@ -741,7 +741,7 @@ mod tests {
             context_size,
             true,
         );
-        let expected_brief = vec!["*** foo\t", "--- bar\t", ""].join("\n");
+        let expected_brief = ["*** foo\t", "--- bar\t", ""].join("\n");
         assert_eq!(diff_brief, expected_brief.as_bytes());
 
         let nodiff_full = diff(

--- a/src/ed_diff.rs
+++ b/src/ed_diff.rs
@@ -170,7 +170,7 @@ mod tests {
         let from = b"a\n";
         let to = b"b\n";
         let diff = diff(from, to, false).unwrap();
-        let expected = vec!["1c", "b", ".", ""].join("\n");
+        let expected = ["1c", "b", ".", ""].join("\n");
         assert_eq!(diff, expected.as_bytes());
     }
 
@@ -401,11 +401,11 @@ mod tests {
 
     #[test]
     fn test_stop_early() {
-        let from = vec!["a", "b", "c", ""].join("\n");
-        let to = vec!["a", "d", "c", ""].join("\n");
+        let from = ["a", "b", "c", ""].join("\n");
+        let to = ["a", "d", "c", ""].join("\n");
 
         let diff_full = diff(from.as_bytes(), to.as_bytes(), false).unwrap();
-        let expected_full = vec!["2c", "d", ".", ""].join("\n");
+        let expected_full = ["2c", "d", ".", ""].join("\n");
         assert_eq!(diff_full, expected_full.as_bytes());
 
         let diff_brief = diff(from.as_bytes(), to.as_bytes(), true).unwrap();

--- a/src/normal_diff.rs
+++ b/src/normal_diff.rs
@@ -549,11 +549,11 @@ mod tests {
 
     #[test]
     fn test_stop_early() {
-        let from = vec!["a", "b", "c"].join("\n");
-        let to = vec!["a", "d", "c"].join("\n");
+        let from = ["a", "b", "c"].join("\n");
+        let to = ["a", "d", "c"].join("\n");
 
         let diff_full = diff(from.as_bytes(), to.as_bytes(), false);
-        let expected_full = vec!["2c2", "< b", "---", "> d", ""].join("\n");
+        let expected_full = ["2c2", "< b", "---", "> d", ""].join("\n");
         assert_eq!(diff_full, expected_full.as_bytes());
 
         let diff_brief = diff(from.as_bytes(), to.as_bytes(), true);

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -857,9 +857,9 @@ mod tests {
     #[test]
     fn test_stop_early() {
         let from_filename = "foo";
-        let from = vec!["a", "b", "c", ""].join("\n");
+        let from = ["a", "b", "c", ""].join("\n");
         let to_filename = "bar";
-        let to = vec!["a", "d", "c", ""].join("\n");
+        let to = ["a", "d", "c", ""].join("\n");
         let context_size: usize = 3;
 
         let diff_full = diff(
@@ -870,7 +870,7 @@ mod tests {
             context_size,
             false,
         );
-        let expected_full = vec![
+        let expected_full = [
             "--- foo\t",
             "+++ bar\t",
             "@@ -1,3 +1,3 @@",
@@ -891,7 +891,7 @@ mod tests {
             context_size,
             true,
         );
-        let expected_brief = vec!["--- foo\t", "+++ bar\t", ""].join("\n");
+        let expected_brief = ["--- foo\t", "+++ bar\t", ""].join("\n");
         assert_eq!(diff_brief, expected_brief.as_bytes());
 
         let nodiff_full = diff(


### PR DESCRIPTION
This PR fixes warnings from the [useless_vec](https://rust-lang.github.io/rust-clippy/master/index.html#/useless_vec) lint.