### PR TITLE
Handle long option names for the supported output styles…

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18,7 +18,7 @@ fn unknown_param() -> Result<(), Box<dyn std::error::Error>> {
     cmd.assert()
         .code(predicate::eq(2))
         .failure()
-        .stderr(predicate::str::starts_with("Usage: "));
+        .stderr(predicate::str::starts_with("Unknown option: \"--foobar\""));
     Ok(())
 }
 


### PR DESCRIPTION
… as well as all valid combinations accepted by GNU diff to request a context/unified diff.

I initially intended to use a ready-made library (like clap) to parse parameters in an easier to read/maintain fashion, but I had to give up on the idea for the sake of compatibility with GNU diff's implementation.