### PR TITLE
Handle directory-file and file-directory comparisons in the diff

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -1,4 +1,5 @@
 use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 
 use regex::Regex;
 
@@ -178,6 +179,20 @@ pub fn parse_params<I: IntoIterator<Item = OsString>>(opts: I) -> Result<Params,
     } else {
         return Err(format!("Usage: {} <from> <to>", exe.to_string_lossy()));
     };
+
+    // diff DIRECTORY FILE => diff DIRECTORY/FILE FILE
+    // diff FILE DIRECTORY => diff FILE DIRECTORY/FILE
+    let mut from_path: PathBuf = PathBuf::from(&params.from);
+    let mut to_path: PathBuf = PathBuf::from(&params.to);
+
+    if from_path.is_dir() && to_path.is_file() {
+        from_path.push(to_path.file_name().unwrap());
+        params.from = from_path.into_os_string();
+    } else if from_path.is_file() && to_path.is_dir() {
+        to_path.push(from_path.file_name().unwrap());
+        params.to = to_path.into_os_string();
+    }
+
     params.format = format.unwrap_or(Format::default());
     Ok(params)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,8 +8,7 @@ use diffutilslib::assert_diff_eq;
 use predicates::prelude::*;
 use std::fs::File;
 use std::io::Write;
-use std::path::PathBuf;
-use tempfile::NamedTempFile;
+use tempfile::{tempdir, NamedTempFile};
 
 // Integration tests for the diffutils command
 
@@ -238,14 +237,13 @@ fn read_from_stdin() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
-fn read_from_directory() -> Result<(), Box<dyn std::error::Error>> {
-    let target = PathBuf::from("target/integration");
-    let _ = std::fs::create_dir(&target);
+fn compare_file_to_directory() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = tempdir()?;
 
-    let directory = target.join("d");
+    let directory = tmp_dir.path().join("d");
     let _ = std::fs::create_dir(&directory);
 
-    let a_path = target.join("a");
+    let a_path = tmp_dir.path().join("a");
     let mut a = File::create(&a_path).unwrap();
     a.write_all(b"a\n").unwrap();
 


### PR DESCRIPTION
GNU diff treats `diff DIRECTORY FILE` as `diff DIRECTORY/FILE FILE`

```console
$ echo a > a
$ mkdir d
$  echo da > d/a
$ diff -u d a
--- d/a	2024-04-20 22:16:11.145369745 +0530
+++ a	2024-04-20 22:15:57.785813179 +0530
@@ -1 +1 @@
-da
+a
$ diff -u a d
--- a	2024-04-20 22:15:57.785813179 +0530
+++ d/a	2024-04-20 22:16:11.145369745 +0530
@@ -1 +1 @@
-a
+da
$ cargo run -- -u d a
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/diffutils -u d a`
--- d/a	2024-04-20 22:16:11.145369745 +0530
+++ a	2024-04-20 22:15:57.785813179 +0530
@@ -1 +1 @@
-da
+a
$ cargo run -- -u a d
    Finished dev [unoptimized + debuginfo] target(s) in 0.02s
     Running `target/debug/diffutils -u a d`
--- a	2024-04-20 22:15:57.785813179 +0530
+++ d/a	2024-04-20 22:16:11.145369745 +0530
@@ -1 +1 @@
-a
+da

```