### PR TITLE
stdin: Handle directory input

### DIFF
--- a/src/context_diff.rs
+++ b/src/context_diff.rs
@@ -269,12 +269,12 @@ fn make_diff(
 #[must_use]
 pub fn diff(expected: &[u8], actual: &[u8], params: &Params) -> Vec<u8> {
     let from_modified_time =
-        match !params.stdin_path.is_empty() && params.from.to_string_lossy().starts_with("-") {
+        match !params.stdin_path.is_empty() && params.from.to_string_lossy().starts_with('-') {
             true => get_modification_time(&params.stdin_path.to_string_lossy()),
             false => get_modification_time(&params.from.to_string_lossy()),
         };
     let to_modified_time =
-        match !params.stdin_path.is_empty() && params.to.to_string_lossy().starts_with("-") {
+        match !params.stdin_path.is_empty() && params.to.to_string_lossy().starts_with('-') {
             true => get_modification_time(&params.stdin_path.to_string_lossy()),
             false => get_modification_time(&params.to.to_string_lossy()),
         };

--- a/src/context_diff.rs
+++ b/src/context_diff.rs
@@ -268,8 +268,16 @@ fn make_diff(
 
 #[must_use]
 pub fn diff(expected: &[u8], actual: &[u8], params: &Params) -> Vec<u8> {
-    let from_modified_time = get_modification_time(&params.from.to_string_lossy());
-    let to_modified_time = get_modification_time(&params.to.to_string_lossy());
+    let from_modified_time =
+        match !params.stdin_path.is_empty() && params.from.to_string_lossy().starts_with("-") {
+            true => get_modification_time(&params.stdin_path.to_string_lossy()),
+            false => get_modification_time(&params.from.to_string_lossy()),
+        };
+    let to_modified_time =
+        match !params.stdin_path.is_empty() && params.to.to_string_lossy().starts_with("-") {
+            true => get_modification_time(&params.stdin_path.to_string_lossy()),
+            false => get_modification_time(&params.to.to_string_lossy()),
+        };
     let mut output = format!(
         "*** {0}\t{1}\n--- {2}\t{3}\n",
         params.from.to_string_lossy(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() -> ExitCode {
     }
     // read files
     fn read_file_contents(filepath: &OsString, stdin_path: &OsString) -> io::Result<Vec<u8>> {
-        if filepath.to_string_lossy().starts_with("-") && !stdin_path.is_empty() {
+        if filepath.to_string_lossy().starts_with('-') && !stdin_path.is_empty() {
             fs::read(stdin_path)
         } else if filepath == "-" {
             let mut content = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,22 +46,24 @@ fn main() -> ExitCode {
         return ExitCode::SUCCESS;
     }
     // read files
-    fn read_file_contents(filepath: &OsString) -> io::Result<Vec<u8>> {
-        if filepath == "-" {
+    fn read_file_contents(filepath: &OsString, stdin_path: &OsString) -> io::Result<Vec<u8>> {
+        if filepath.to_string_lossy().starts_with("-") && !stdin_path.is_empty() {
+            fs::read(stdin_path)
+        } else if filepath == "-" {
             let mut content = Vec::new();
             io::stdin().read_to_end(&mut content).and(Ok(content))
         } else {
             fs::read(filepath)
         }
     }
-    let from_content = match read_file_contents(&params.from) {
+    let from_content = match read_file_contents(&params.from, &params.stdin_path) {
         Ok(from_content) => from_content,
         Err(e) => {
             eprintln!("Failed to read from-file: {e}");
             return ExitCode::from(2);
         }
     };
-    let to_content = match read_file_contents(&params.to) {
+    let to_content = match read_file_contents(&params.to, &params.stdin_path) {
         Ok(to_content) => to_content,
         Err(e) => {
             eprintln!("Failed to read to-file: {e}");

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,5 +1,10 @@
 use std::ffi::OsString;
+use std::fs;
 use std::path::PathBuf;
+
+use std::fs::File;
+use std::io::stdin;
+use std::os::fd::AsFd;
 
 use regex::Regex;
 
@@ -16,6 +21,7 @@ pub enum Format {
 pub struct Params {
     pub from: OsString,
     pub to: OsString,
+    pub stdin_path: OsString,
     pub format: Format,
     pub context_count: usize,
     pub report_identical_files: bool,
@@ -29,6 +35,7 @@ impl Default for Params {
         Self {
             from: OsString::default(),
             to: OsString::default(),
+            stdin_path: OsString::default(),
             format: Format::default(),
             context_count: 3,
             report_identical_files: false,
@@ -178,10 +185,25 @@ pub fn parse_params<I: IntoIterator<Item = OsString>>(opts: I) -> Result<Params,
     let mut from_path: PathBuf = PathBuf::from(&params.from);
     let mut to_path: PathBuf = PathBuf::from(&params.to);
 
-    if from_path.is_dir() && to_path.is_file() {
+    // check if stdin is a directory
+    let fd = stdin().as_fd().try_clone_to_owned().unwrap();
+    let file = File::from(fd);
+    let meta = file.metadata().unwrap();
+    if meta.is_dir() {
+        let stdin = fs::canonicalize("/dev/stdin").unwrap();
+        let mut stdin_path: PathBuf = PathBuf::from(stdin);
+        if params.from == "-" {
+            stdin_path.push(&to_path.file_name().unwrap());
+        } else {
+            stdin_path.push(&from_path.file_name().unwrap());
+        }
+        params.stdin_path = stdin_path.into();
+    }
+
+    if (from_path.is_dir() || !params.stdin_path.is_empty()) && to_path.is_file() {
         from_path.push(to_path.file_name().unwrap());
         params.from = from_path.into_os_string();
-    } else if from_path.is_file() && to_path.is_dir() {
+    } else if from_path.is_file() && (to_path.is_dir() || !params.stdin_path.is_empty()) {
         to_path.push(from_path.file_name().unwrap());
         params.to = to_path.into_os_string();
     }

--- a/src/params.rs
+++ b/src/params.rs
@@ -190,12 +190,11 @@ pub fn parse_params<I: IntoIterator<Item = OsString>>(opts: I) -> Result<Params,
     let file = File::from(fd);
     let meta = file.metadata().unwrap();
     if meta.is_dir() {
-        let stdin = fs::canonicalize("/dev/stdin").unwrap();
-        let mut stdin_path: PathBuf = PathBuf::from(stdin);
+        let mut stdin_path = fs::canonicalize("/dev/stdin").unwrap();
         if params.from == "-" {
-            stdin_path.push(&to_path.file_name().unwrap());
+            stdin_path.push(to_path.file_name().unwrap());
         } else {
-            stdin_path.push(&from_path.file_name().unwrap());
+            stdin_path.push(from_path.file_name().unwrap());
         }
         params.stdin_path = stdin_path.into();
     }

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -240,12 +240,12 @@ fn make_diff(
 #[must_use]
 pub fn diff(expected: &[u8], actual: &[u8], params: &Params) -> Vec<u8> {
     let from_modified_time =
-        match !params.stdin_path.is_empty() && params.from.to_string_lossy().starts_with("-") {
+        match !params.stdin_path.is_empty() && params.from.to_string_lossy().starts_with('-') {
             true => get_modification_time(&params.stdin_path.to_string_lossy()),
             false => get_modification_time(&params.from.to_string_lossy()),
         };
     let to_modified_time =
-        match !params.stdin_path.is_empty() && params.to.to_string_lossy().starts_with("-") {
+        match !params.stdin_path.is_empty() && params.to.to_string_lossy().starts_with('-') {
             true => get_modification_time(&params.stdin_path.to_string_lossy()),
             false => get_modification_time(&params.to.to_string_lossy()),
         };

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -239,8 +239,16 @@ fn make_diff(
 
 #[must_use]
 pub fn diff(expected: &[u8], actual: &[u8], params: &Params) -> Vec<u8> {
-    let from_modified_time = get_modification_time(&params.from.to_string_lossy());
-    let to_modified_time = get_modification_time(&params.to.to_string_lossy());
+    let from_modified_time =
+        match !params.stdin_path.is_empty() && params.from.to_string_lossy().starts_with("-") {
+            true => get_modification_time(&params.stdin_path.to_string_lossy()),
+            false => get_modification_time(&params.from.to_string_lossy()),
+        };
+    let to_modified_time =
+        match !params.stdin_path.is_empty() && params.to.to_string_lossy().starts_with("-") {
+            true => get_modification_time(&params.stdin_path.to_string_lossy()),
+            false => get_modification_time(&params.to.to_string_lossy()),
+        };
     let mut output = format!(
         "--- {0}\t{1}\n+++ {2}\t{3}\n",
         params.from.to_string_lossy(),


### PR DESCRIPTION
When handling stdin, GNU diff now behaves as follows:
  * If a file is input, it displays the current time as m_time
  * If a directory is input, it appends the other file_name to the canonicalized path of directory and reads and displays the m_time of that file