### PR TITLE
Fix clippy warnings in tests

### DIFF
--- a/src/context_diff.rs
+++ b/src/context_diff.rs
@@ -439,26 +439,26 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/ab.diff"))
+                                File::create(format!("{target}/ab.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
                                     .arg("--context")
-                                    .stdin(File::open(&format!("{target}/ab.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/ab.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alef")).unwrap();
+                                let alef = fs::read(format!("{target}/alef")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -520,26 +520,26 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/ab_.diff"))
+                                File::create(format!("{target}/ab_.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef_")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef_")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet_")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet_")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
                                     .arg("--context")
-                                    .stdin(File::open(&format!("{target}/ab_.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/ab_.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alef_")).unwrap();
+                                let alef = fs::read(format!("{target}/alef_")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -604,26 +604,26 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/abx.diff"))
+                                File::create(format!("{target}/abx.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alefx")).unwrap();
+                                let mut fa = File::create(format!("{target}/alefx")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/betx")).unwrap();
+                                let mut fb = File::create(format!("{target}/betx")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
                                     .arg("--context")
-                                    .stdin(File::open(&format!("{target}/abx.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/abx.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alefx")).unwrap();
+                                let alef = fs::read(format!("{target}/alefx")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -691,26 +691,26 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/abr.diff"))
+                                File::create(format!("{target}/abr.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alefr")).unwrap();
+                                let mut fa = File::create(format!("{target}/alefr")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/betr")).unwrap();
+                                let mut fb = File::create(format!("{target}/betr")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
                                     .arg("--context")
-                                    .stdin(File::open(&format!("{target}/abr.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/abr.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alefr")).unwrap();
+                                let alef = fs::read(format!("{target}/alefr")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }

--- a/src/ed_diff.rs
+++ b/src/ed_diff.rs
@@ -225,13 +225,13 @@ mod tests {
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
                                 let diff = diff_w(&alef, &bet, &format!("{target}/alef")).unwrap();
-                                File::create(&format!("{target}/ab.ed"))
+                                File::create(format!("{target}/ab.ed"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
@@ -239,14 +239,14 @@ mod tests {
                                 {
                                     use std::process::Command;
                                     let output = Command::new("ed")
-                                        .arg(&format!("{target}/alef"))
-                                        .stdin(File::open(&format!("{target}/ab.ed")).unwrap())
+                                        .arg(format!("{target}/alef"))
+                                        .stdin(File::open(format!("{target}/ab.ed")).unwrap())
                                         .output()
                                         .unwrap();
                                     assert!(output.status.success(), "{output:?}");
                                     //println!("{}", String::from_utf8_lossy(&output.stdout));
                                     //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                    let alef = std::fs::read(&format!("{target}/alef")).unwrap();
+                                    let alef = std::fs::read(format!("{target}/alef")).unwrap();
                                     assert_eq!(alef, bet);
                                 }
                             }
@@ -299,13 +299,13 @@ mod tests {
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
                                 let diff = diff_w(&alef, &bet, &format!("{target}/alef_")).unwrap();
-                                File::create(&format!("{target}/ab_.ed"))
+                                File::create(format!("{target}/ab_.ed"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef_")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef_")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet_")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet_")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
@@ -313,14 +313,14 @@ mod tests {
                                 {
                                     use std::process::Command;
                                     let output = Command::new("ed")
-                                        .arg(&format!("{target}/alef_"))
-                                        .stdin(File::open(&format!("{target}/ab_.ed")).unwrap())
+                                        .arg(format!("{target}/alef_"))
+                                        .stdin(File::open(format!("{target}/ab_.ed")).unwrap())
                                         .output()
                                         .unwrap();
                                     assert!(output.status.success(), "{output:?}");
                                     //println!("{}", String::from_utf8_lossy(&output.stdout));
                                     //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                    let alef = std::fs::read(&format!("{target}/alef_")).unwrap();
+                                    let alef = std::fs::read(format!("{target}/alef_")).unwrap();
                                     assert_eq!(alef, bet);
                                 }
                             }
@@ -379,13 +379,13 @@ mod tests {
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
                                 let diff = diff_w(&alef, &bet, &format!("{target}/alefr")).unwrap();
-                                File::create(&format!("{target}/abr.ed"))
+                                File::create(format!("{target}/abr.ed"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alefr")).unwrap();
+                                let mut fa = File::create(format!("{target}/alefr")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/betr")).unwrap();
+                                let mut fb = File::create(format!("{target}/betr")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
@@ -393,14 +393,14 @@ mod tests {
                                 {
                                     use std::process::Command;
                                     let output = Command::new("ed")
-                                        .arg(&format!("{target}/alefr"))
-                                        .stdin(File::open(&format!("{target}/abr.ed")).unwrap())
+                                        .arg(format!("{target}/alefr"))
+                                        .stdin(File::open(format!("{target}/abr.ed")).unwrap())
                                         .output()
                                         .unwrap();
                                     assert!(output.status.success(), "{output:?}");
                                     //println!("{}", String::from_utf8_lossy(&output.stdout));
                                     //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                    let alef = std::fs::read(&format!("{target}/alefr")).unwrap();
+                                    let alef = std::fs::read(format!("{target}/alefr")).unwrap();
                                     assert_eq!(alef, bet);
                                 }
                             }

--- a/src/normal_diff.rs
+++ b/src/normal_diff.rs
@@ -275,26 +275,26 @@ mod tests {
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
                                 let diff = diff(&alef, &bet, &Params::default());
-                                File::create(&format!("{target}/ab.diff"))
+                                File::create(format!("{target}/ab.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
-                                    .arg(&format!("{target}/alef"))
-                                    .stdin(File::open(&format!("{target}/ab.diff")).unwrap())
+                                    .arg(format!("{target}/alef"))
+                                    .stdin(File::open(format!("{target}/ab.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alef")).unwrap();
+                                let alef = fs::read(format!("{target}/alef")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -367,27 +367,27 @@ mod tests {
                                     // This test diff is intentionally reversed.
                                     // We want it to turn the alef into bet.
                                     let diff = diff(&alef, &bet, &Params::default());
-                                    File::create(&format!("{target}/abn.diff"))
+                                    File::create(format!("{target}/abn.diff"))
                                         .unwrap()
                                         .write_all(&diff)
                                         .unwrap();
-                                    let mut fa = File::create(&format!("{target}/alefn")).unwrap();
+                                    let mut fa = File::create(format!("{target}/alefn")).unwrap();
                                     fa.write_all(&alef[..]).unwrap();
-                                    let mut fb = File::create(&format!("{target}/betn")).unwrap();
+                                    let mut fb = File::create(format!("{target}/betn")).unwrap();
                                     fb.write_all(&bet[..]).unwrap();
                                     let _ = fa;
                                     let _ = fb;
                                     let output = Command::new("patch")
                                         .arg("-p0")
                                         .arg("--normal")
-                                        .arg(&format!("{target}/alefn"))
-                                        .stdin(File::open(&format!("{target}/abn.diff")).unwrap())
+                                        .arg(format!("{target}/alefn"))
+                                        .stdin(File::open(format!("{target}/abn.diff")).unwrap())
                                         .output()
                                         .unwrap();
                                     assert!(output.status.success(), "{output:?}");
                                     //println!("{}", String::from_utf8_lossy(&output.stdout));
                                     //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                    let alef = fs::read(&format!("{target}/alefn")).unwrap();
+                                    let alef = fs::read(format!("{target}/alefn")).unwrap();
                                     assert_eq!(alef, bet);
                                 }
                             }
@@ -441,26 +441,26 @@ mod tests {
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
                                 let diff = diff(&alef, &bet, &Params::default());
-                                File::create(&format!("{target}/ab_.diff"))
+                                File::create(format!("{target}/ab_.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef_")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef_")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet_")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet_")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
-                                    .arg(&format!("{target}/alef_"))
-                                    .stdin(File::open(&format!("{target}/ab_.diff")).unwrap())
+                                    .arg(format!("{target}/alef_"))
+                                    .stdin(File::open(format!("{target}/ab_.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alef_")).unwrap();
+                                let alef = fs::read(format!("{target}/alef_")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -519,26 +519,26 @@ mod tests {
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
                                 let diff = diff(&alef, &bet, &Params::default());
-                                File::create(&format!("{target}/abr.diff"))
+                                File::create(format!("{target}/abr.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alefr")).unwrap();
+                                let mut fa = File::create(format!("{target}/alefr")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/betr")).unwrap();
+                                let mut fb = File::create(format!("{target}/betr")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
-                                    .arg(&format!("{target}/alefr"))
-                                    .stdin(File::open(&format!("{target}/abr.diff")).unwrap())
+                                    .arg(format!("{target}/alefr"))
+                                    .stdin(File::open(format!("{target}/abr.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alefr")).unwrap();
+                                let alef = fs::read(format!("{target}/alefr")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -466,13 +466,13 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/ab.diff"))
+                                File::create(format!("{target}/ab.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alef")).unwrap();
+                                let mut fa = File::create(format!("{target}/alef")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/bet")).unwrap();
+                                let mut fb = File::create(format!("{target}/bet")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
@@ -494,13 +494,13 @@ mod tests {
 
                                 let output = Command::new("patch")
                                     .arg("-p0")
-                                    .stdin(File::open(&format!("{target}/ab.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/ab.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 println!("{}", String::from_utf8_lossy(&output.stdout));
                                 println!("{}", String::from_utf8_lossy(&output.stderr));
                                 assert!(output.status.success(), "{output:?}");
-                                let alef = fs::read(&format!("{target}/alef")).unwrap();
+                                let alef = fs::read(format!("{target}/alef")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -582,25 +582,25 @@ mod tests {
                                             ..Default::default()
                                         },
                                     );
-                                    File::create(&format!("{target}/abn.diff"))
+                                    File::create(format!("{target}/abn.diff"))
                                         .unwrap()
                                         .write_all(&diff)
                                         .unwrap();
-                                    let mut fa = File::create(&format!("{target}/alefn")).unwrap();
+                                    let mut fa = File::create(format!("{target}/alefn")).unwrap();
                                     fa.write_all(&alef[..]).unwrap();
-                                    let mut fb = File::create(&format!("{target}/betn")).unwrap();
+                                    let mut fb = File::create(format!("{target}/betn")).unwrap();
                                     fb.write_all(&bet[..]).unwrap();
                                     let _ = fa;
                                     let _ = fb;
                                     let output = Command::new("patch")
                                         .arg("-p0")
-                                        .stdin(File::open(&format!("{target}/abn.diff")).unwrap())
+                                        .stdin(File::open(format!("{target}/abn.diff")).unwrap())
                                         .output()
                                         .unwrap();
                                     assert!(output.status.success(), "{output:?}");
                                     //println!("{}", String::from_utf8_lossy(&output.stdout));
                                     //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                    let alef = fs::read(&format!("{target}/alefn")).unwrap();
+                                    let alef = fs::read(format!("{target}/alefn")).unwrap();
                                     assert_eq!(alef, bet);
                                 }
                             }
@@ -678,25 +678,25 @@ mod tests {
                                             ..Default::default()
                                         },
                                     );
-                                    File::create(&format!("{target}/ab_.diff"))
+                                    File::create(format!("{target}/ab_.diff"))
                                         .unwrap()
                                         .write_all(&diff)
                                         .unwrap();
-                                    let mut fa = File::create(&format!("{target}/alef_")).unwrap();
+                                    let mut fa = File::create(format!("{target}/alef_")).unwrap();
                                     fa.write_all(&alef[..]).unwrap();
-                                    let mut fb = File::create(&format!("{target}/bet_")).unwrap();
+                                    let mut fb = File::create(format!("{target}/bet_")).unwrap();
                                     fb.write_all(&bet[..]).unwrap();
                                     let _ = fa;
                                     let _ = fb;
                                     let output = Command::new("patch")
                                         .arg("-p0")
-                                        .stdin(File::open(&format!("{target}/ab_.diff")).unwrap())
+                                        .stdin(File::open(format!("{target}/ab_.diff")).unwrap())
                                         .output()
                                         .unwrap();
                                     assert!(output.status.success(), "{output:?}");
                                     //println!("{}", String::from_utf8_lossy(&output.stdout));
                                     //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                    let alef = fs::read(&format!("{target}/alef_")).unwrap();
+                                    let alef = fs::read(format!("{target}/alef_")).unwrap();
                                     assert_eq!(alef, bet);
                                 }
                             }
@@ -759,25 +759,25 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/abx.diff"))
+                                File::create(format!("{target}/abx.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alefx")).unwrap();
+                                let mut fa = File::create(format!("{target}/alefx")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/betx")).unwrap();
+                                let mut fb = File::create(format!("{target}/betx")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
-                                    .stdin(File::open(&format!("{target}/abx.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/abx.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alefx")).unwrap();
+                                let alef = fs::read(format!("{target}/alefx")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }
@@ -845,25 +845,25 @@ mod tests {
                                         ..Default::default()
                                     },
                                 );
-                                File::create(&format!("{target}/abr.diff"))
+                                File::create(format!("{target}/abr.diff"))
                                     .unwrap()
                                     .write_all(&diff)
                                     .unwrap();
-                                let mut fa = File::create(&format!("{target}/alefr")).unwrap();
+                                let mut fa = File::create(format!("{target}/alefr")).unwrap();
                                 fa.write_all(&alef[..]).unwrap();
-                                let mut fb = File::create(&format!("{target}/betr")).unwrap();
+                                let mut fb = File::create(format!("{target}/betr")).unwrap();
                                 fb.write_all(&bet[..]).unwrap();
                                 let _ = fa;
                                 let _ = fb;
                                 let output = Command::new("patch")
                                     .arg("-p0")
-                                    .stdin(File::open(&format!("{target}/abr.diff")).unwrap())
+                                    .stdin(File::open(format!("{target}/abr.diff")).unwrap())
                                     .output()
                                     .unwrap();
                                 assert!(output.status.success(), "{output:?}");
                                 //println!("{}", String::from_utf8_lossy(&output.stdout));
                                 //println!("{}", String::from_utf8_lossy(&output.stderr));
-                                let alef = fs::read(&format!("{target}/alefr")).unwrap();
+                                let alef = fs::read(format!("{target}/alefr")).unwrap();
                                 assert_eq!(alef, bet);
                             }
                         }


### PR DESCRIPTION
This PR fixes warnings from the [needless_borrows_for_generic_args](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_borrows_for_generic_args) lint.