### PR TITLE
Fix clippy warnings

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -691,12 +691,12 @@ mod cmp {
 
         let a_path = tmp_dir.path().join("a");
         let mut a = File::create(&a_path).unwrap();
-        write!(a, "{}c\n", "a".repeat(1024)).unwrap();
+        writeln!(a, "{}c", "a".repeat(1024)).unwrap();
         a.flush().unwrap();
 
         let b_path = tmp_dir.path().join("b");
         let mut b = File::create(&b_path).unwrap();
-        write!(b, "{}c\n", "b".repeat(1024)).unwrap();
+        writeln!(b, "{}c", "b".repeat(1024)).unwrap();
         b.flush().unwrap();
 
         let mut cmd = Command::cargo_bin("diffutils")?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -851,12 +851,12 @@ mod cmp {
 
         let a_path = tmp_dir.path().join("a");
         let mut a = File::create(&a_path).unwrap();
-        a.write_all(&bytes).unwrap();
+        a.write_all(bytes).unwrap();
         a.write_all(b"A").unwrap();
 
         let b_path = tmp_dir.path().join("b");
         let mut b = File::create(&b_path).unwrap();
-        b.write_all(&bytes).unwrap();
+        b.write_all(bytes).unwrap();
         b.write_all(b"B").unwrap();
 
         let mut cmd = Command::cargo_bin("diffutils")?;


### PR DESCRIPTION
This PR fixes some warnings from the [write_with_newline](https://rust-lang.github.io/rust-clippy/master/index.html#write_with_newline) and [needless_borrow](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow) lints.