### PR TITLE
Fix "unused import" warning on Windows

### DIFF
--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,9 @@
 
 use assert_cmd::cmd::Command;
 use predicates::prelude::*;
-use std::fs::{File, OpenOptions};
+use std::fs::File;
+#[cfg(not(windows))]
+use std::fs::OpenOptions;
 use std::io::Write;
 use tempfile::{tempdir, NamedTempFile};
 


### PR DESCRIPTION
This PR fixes an "unused import" warning on Windows I noticed while looking at the "Code coverage" jobs (see https://github.com/uutils/diffutils/actions/runs/11737056572/job/32697251902#step:8:87).