### PR TITLE
ci: remove `CARGO_FEATURES_OPTION`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,8 +102,6 @@ jobs:
         if [ -n "${{ matrix.job.toolchain }}" ]; then TOOLCHAIN="${{ matrix.job.toolchain }}" ; fi
         outputs TOOLCHAIN
         # target-specific options
-        # * CARGO_FEATURES_OPTION
-        CARGO_FEATURES_OPTION='--all -- --check' ;  ## default to '--all-features' for code coverage
         # * CODECOV_FLAGS
         CODECOV_FLAGS=$( echo "${{ matrix.job.os }}" | sed 's/[^[:alnum:]]/_/g' )
         outputs CODECOV_FLAGS
@@ -119,7 +117,7 @@ jobs:
       if: runner.os == 'Windows'
       run: echo "C:\Program Files\Git\usr\bin" >> $env:GITHUB_PATH
     - name: Test
-      run: cargo test ${{ steps.vars.outputs.CARGO_FEATURES_OPTION }} --no-fail-fast
+      run: cargo test --all-features --no-fail-fast
       env:
         CARGO_INCREMENTAL: "0"
         RUSTC_WRAPPER: ""


### PR DESCRIPTION
While looking at the "code coverage" jobs I noticed that `CARGO_FEATURES_OPTION` is always empty when it's used. <del>This PR adds the missing `outputs CARGO_FEATURES_OPTION` to `ci.yml`, though I'm not sure whether `CARGO_FEATURES_OPTION` is even needed.</del> This PR removes `CARGO_FEATURES_OPTION` and adds `--all-features` to where `CARGO_FEATURES_OPTION` was used.