### PR TITLE
clippy: fix warnings

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -35,7 +35,7 @@ pub struct Params {
 
 #[inline]
 fn usage_string(executable: &str) -> String {
-    format!("Usage: {} <from> <to>", executable)
+    format!("Usage: {executable} <from> <to>")
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -75,8 +75,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
             Err(e) if *e.kind() == std::num::IntErrorKind::PosOverflow => usize::MAX,
             Err(_) => {
                 return Err(format!(
-                    "{}: invalid --ignore-initial value '{}'",
-                    executable_str, skip_desc
+                    "{executable_str}: invalid --ignore-initial value '{skip_desc}'"
                 ))
             }
         };
@@ -103,8 +102,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
                 "Y" => usize::MAX,  // 1_208_925_819_614_629_174_706_176,
                 _ => {
                     return Err(format!(
-                        "{}: invalid --ignore-initial value '{}'",
-                        executable_str, skip_desc
+                        "{executable_str}: invalid --ignore-initial value '{skip_desc}'"
                     ));
                 }
             };
@@ -170,8 +168,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
                 Err(e) if *e.kind() == std::num::IntErrorKind::PosOverflow => usize::MAX,
                 Err(_) => {
                     return Err(format!(
-                        "{}: invalid --bytes value '{}'",
-                        executable_str, max_bytes
+                        "{executable_str}: invalid --bytes value '{max_bytes}'"
                     ))
                 }
             };
@@ -210,7 +207,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
             std::process::exit(0);
         }
         if param_str.starts_with('-') {
-            return Err(format!("Unknown option: {:?}", param));
+            return Err(format!("Unknown option: {param:?}"));
         }
         if from.is_none() {
             from = Some(param);
@@ -236,8 +233,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
 
     if params.quiet && params.verbose {
         return Err(format!(
-            "{}: options -l and -s are incompatible",
-            executable_str
+            "{executable_str}: options -l and -s are incompatible"
         ));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> ExitCode {
         Some("diff") => diff::main(args),
         Some("cmp") => cmp::main(args),
         Some(name) => {
-            eprintln!("{}: utility not supported", name);
+            eprintln!("{name}: utility not supported");
             ExitCode::from(2)
         }
         None => second_arg_error(exe_name),

--- a/src/params.rs
+++ b/src/params.rs
@@ -195,7 +195,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
             Err(error) => return Err(error),
         }
         if param.to_string_lossy().starts_with('-') {
-            return Err(format!("Unknown option: {:?}", param));
+            return Err(format!("Unknown option: {param:?}"));
         }
         if from.is_none() {
             from = Some(param);

--- a/src/side_diff.rs
+++ b/src/side_diff.rs
@@ -950,10 +950,7 @@ mod tests {
             push_output(left_ln, right_ln, symbol, &mut buf, &config).unwrap();
             let expected_left = format!("áéíóú\t\t\t\t\t\t\t\t");
             let expected_right = "😀😃😄";
-            assert_eq!(
-                buf,
-                format!("{}{}\n", expected_left, expected_right).as_bytes()
-            );
+            assert_eq!(buf, format!("{expected_left}{expected_right}\n").as_bytes());
         }
     }
 

--- a/src/side_diff.rs
+++ b/src/side_diff.rs
@@ -973,7 +973,7 @@ mod tests {
             }
         }
 
-        fn contains_string(vec: &Vec<u8>, s: &str) -> usize {
+        fn contains_string(vec: &[u8], s: &str) -> usize {
             let pattern = s.as_bytes();
             vec.windows(pattern.len()).filter(|s| s == &pattern).count()
         }

--- a/src/side_diff.rs
+++ b/src/side_diff.rs
@@ -901,7 +901,7 @@ mod tests {
             let symbol = b'<'; // impossible case, just to use different symbol
             let mut buf = vec![];
             push_output(left_ln, right_ln, symbol, &mut buf, &config).unwrap();
-            assert_eq!(buf, format!("data\t\t\t\t\t\t\t      <\n").as_bytes());
+            assert_eq!(buf, "data\t\t\t\t\t\t\t      <\n".as_bytes());
         }
 
         #[test]
@@ -948,7 +948,7 @@ mod tests {
             let symbol = b' ';
             let mut buf = vec![];
             push_output(left_ln, right_ln, symbol, &mut buf, &config).unwrap();
-            let expected_left = format!("áéíóú\t\t\t\t\t\t\t\t");
+            let expected_left = "áéíóú\t\t\t\t\t\t\t\t";
             let expected_right = "😀😃😄";
             assert_eq!(buf, format!("{expected_left}{expected_right}\n").as_bytes());
         }


### PR DESCRIPTION
This PR fixes warnings from the [uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args), [useless_format](https://rust-lang.github.io/rust-clippy/master/index.html#useless_format), and [ptr_arg](https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg) lints.