### PR TITLE
`sdiff` initial implementation

### DIFF
--- a/fuzz/fuzz_targets/fuzz_side.rs
+++ b/fuzz/fuzz_targets/fuzz_side.rs
@@ -2,11 +2,10 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 
-use diffutilslib::side_diff;
+use diffutilslib::side_diff::{self, Params};
 
 use std::fs::File;
 use std::io::Write;
-use diffutilslib::params::Params;
 
 fuzz_target!(|x: (Vec<u8>, Vec<u8>, /* usize, usize */ bool)| {
     let (original, new, /* width, tabsize, */ expand) = x;
@@ -22,7 +21,16 @@ fuzz_target!(|x: (Vec<u8>, Vec<u8>, /* usize, usize */ bool)| {
         ..Default::default()
     };
     let mut output_buf = vec![];
-    side_diff::diff(&original, &new, &mut output_buf, &params);
+    side_diff::diff(
+        &original,
+        &new,
+        &mut output_buf,
+        &Params {
+            width: params.width,
+            tabsize: params.tabsize,
+            expand_tabs: params.expand_tabs,
+        },
+    );
     File::create("target/fuzz.file.original")
         .unwrap()
         .write_all(&original)
@@ -40,3 +48,4 @@ fuzz_target!(|x: (Vec<u8>, Vec<u8>, /* usize, usize */ bool)| {
         .write_all(&output_buf)
         .unwrap();
 });
+

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -61,7 +61,16 @@ pub fn main(opts: Peekable<ArgsOs>) -> ExitCode {
         }),
         Format::SideBySide => {
             let mut output = stdout().lock();
-            side_diff::diff(&from_content, &to_content, &mut output, &params)
+            side_diff::diff(
+                &from_content,
+                &to_content,
+                &mut output,
+                &side_diff::Params {
+                    tabsize: params.tabsize,
+                    width: params.width,
+                    expand_tabs: params.expand_tabs,
+                },
+            )
         }
     };
     if params.brief && !result.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ mod ed_diff;
 mod macros;
 mod normal_diff;
 mod params;
+mod sdiff;
 mod side_diff;
 mod unified_diff;
 mod utils;
@@ -72,6 +73,7 @@ fn main() -> ExitCode {
     match util_name.to_str() {
         Some("diff") => diff::main(args),
         Some("cmp") => cmp::main(args),
+        Some("sdiff") => sdiff::main(args),
         Some(name) => {
             eprintln!("{name}: utility not supported");
             ExitCode::from(2)

--- a/src/sdiff.rs
+++ b/src/sdiff.rs
@@ -1,0 +1,221 @@
+// This file is part of the uutils diffutils package.
+//
+// For the full copyright and license information, please view the LICENSE-*
+// files that was distributed with this source code.
+
+use regex::Regex;
+
+// use crate::params::parse_params;
+use crate::side_diff;
+use crate::utils;
+use std::env::ArgsOs;
+use std::ffi::OsString;
+use std::io::{self, stdout, Write};
+use std::iter::Peekable;
+use std::process::{exit, ExitCode};
+
+#[derive(Eq, PartialEq, Debug)]
+pub struct Params {
+    pub executable: OsString,
+    pub from: OsString,
+    pub to: OsString,
+    pub expand_tabs: bool,
+    pub tabsize: usize,
+    pub width: usize,
+}
+
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            executable: OsString::default(),
+            from: OsString::default(),
+            to: OsString::default(),
+            expand_tabs: false,
+            tabsize: 8,
+            width: 130,
+        }
+    }
+}
+
+pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Result<Params, String> {
+    let Some(executable) = opts.next() else {
+        return Err("Usage: <exe> <from> <to>".to_string());
+    };
+
+    let mut params = Params {
+        executable,
+        ..Default::default()
+    };
+
+    let mut from = None;
+    let mut to = None;
+    let tabsize_re = Regex::new(r"^--tabsize=(?<num>\d+)$").unwrap();
+    let width_re = Regex::new(r"--width=(?P<long>\d+)$").unwrap();
+
+    while let Some(param) = opts.next() {
+        if param == "-" {
+            if from.is_none() {
+                from = Some(param);
+            } else if to.is_none() {
+                to = Some(param);
+            } else {
+                return Err(format!(
+                    "Usage: {} <from> <to>",
+                    params.executable.to_string_lossy()
+                ));
+            }
+            continue;
+        }
+
+        if param == "-t" || param == "--expand-tabs" {
+            params.expand_tabs = true;
+            continue;
+        }
+
+        if tabsize_re.is_match(param.to_string_lossy().as_ref()) {
+            // Because param matches the regular expression,
+            // it is safe to assume it is valid UTF-8.
+            let param = param.into_string().unwrap();
+            let tabsize_str = tabsize_re
+                .captures(param.as_str())
+                .unwrap()
+                .name("num")
+                .unwrap()
+                .as_str();
+            params.tabsize = match tabsize_str.parse::<usize>() {
+                Ok(num) => {
+                    if num == 0 {
+                        return Err("invalid tabsize «0»".to_string());
+                    }
+
+                    num
+                }
+                Err(_) => return Err(format!("invalid tabsize «{tabsize_str}»")),
+            };
+
+            continue;
+        }
+
+        if width_re.is_match(param.to_string_lossy().as_ref()) {
+            let param = param.into_string().unwrap();
+            let width_str: &str = width_re
+                .captures(param.as_str())
+                .unwrap()
+                .name("long")
+                .unwrap()
+                .as_str();
+
+            params.width = match width_str.parse::<usize>() {
+                Ok(num) => {
+                    if num == 0 {
+                        return Err("invalid width «0»".to_string());
+                    }
+
+                    num
+                }
+                Err(_) => return Err(format!("invalid width «{width_str}»")),
+            };
+            continue;
+        }
+
+        if from.is_none() {
+            from = Some(param);
+        } else if to.is_none() {
+            to = Some(param);
+        } else {
+            return Err(format!(
+                "Usage: {} <from> <to>",
+                params.executable.to_string_lossy()
+            ));
+        }
+    }
+
+    params.from = if let Some(from) = from {
+        from
+    } else if let Some(param) = opts.next() {
+        param
+    } else {
+        return Err(format!("Err"));
+    };
+
+    params.to = if let Some(to) = to {
+        to
+    } else if let Some(param) = opts.next() {
+        param
+    } else {
+        return Err(format!("Err"));
+    };
+
+    Ok(params)
+}
+
+pub fn main(opts: Peekable<ArgsOs>) -> ExitCode {
+    let params = parse_params(opts).unwrap_or_else(|error| {
+        eprintln!("{error}");
+        exit(2);
+    });
+
+    if params.from == "-" && params.to == "-"
+        || same_file::is_same_file(&params.from, &params.to).unwrap_or(false)
+    {
+        return ExitCode::SUCCESS;
+    }
+
+    let (from_content, to_content) = match utils::read_both_files(&params.from, &params.to) {
+        Ok(contents) => contents,
+        Err((filepath, error)) => {
+            eprintln!(
+                "{}",
+                utils::format_failure_to_read_input_file(&params.executable, &filepath, &error)
+            );
+            return ExitCode::from(2);
+        }
+    };
+
+    // run diff
+    let mut output = stdout().lock();
+    let result = side_diff::diff(
+        &from_content,
+        &to_content,
+        &mut output,
+        &side_diff::Params {
+            tabsize: params.tabsize,
+            width: params.width,
+            expand_tabs: params.expand_tabs,
+        },
+    );
+
+    io::stdout().write_all(&result).unwrap();
+    if result.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::from(1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(s: &str) -> OsString {
+        OsString::from(s)
+    }
+
+    #[test]
+    fn sdiff_params() {
+        assert_eq!(
+            Ok(Params {
+                executable: os("sdiff"),
+                from: os("foo"),
+                to: os("bar"),
+                ..Default::default()
+            }),
+            parse_params(
+                [os("sdiff"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        )
+    }
+}

--- a/src/sdiff.rs
+++ b/src/sdiff.rs
@@ -222,6 +222,129 @@ mod tests {
                     .cloned()
                     .peekable()
             )
+        );
+
+        assert_eq!(
+            Ok(Params {
+                executable: os("sdiff"),
+                from: os("foo"),
+                to: os("bar"),
+                ..Default::default()
+            }),
+            parse_params(
+                [os("sdiff"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        );
+        for option in ["-t", "--expand-tabs"] {
+            assert_eq!(
+                Ok(Params {
+                    executable: os("sdiff"),
+                    from: os("foo"),
+                    to: os("bar"),
+                    expand_tabs: true,
+                    ..Default::default()
+                }),
+                parse_params(
+                    [os("sdiff"), os(option), os("foo"), os("bar")]
+                        .iter()
+                        .cloned()
+                        .peekable()
+                )
+            );
+        }
+        assert_eq!(
+            Ok(Params {
+                executable: os("sdiff"),
+                from: os("foo"),
+                to: os("bar"),
+                ..Default::default()
+            }),
+            parse_params(
+                [os("sdiff"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        );
+        assert_eq!(
+            Ok(Params {
+                executable: os("sdiff"),
+                from: os("foo"),
+                to: os("bar"),
+                tabsize: 1,
+                ..Default::default()
+            }),
+            parse_params(
+                [os("sdiff"), os("--tabsize=1"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        );
+        assert_eq!(
+            Ok(Params {
+                executable: os("sdiff"),
+                from: os("foo"),
+                to: os("bar"),
+                tabsize: 42,
+                ..Default::default()
+            }),
+            parse_params(
+                [os("sdiff"), os("--tabsize=42"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        );
+        assert!(parse_params(
+            [os("sdiff"), os("--tabsize"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
         )
+        .is_err());
+        assert!(parse_params(
+            [os("sdiff"), os("--tabsize="), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+        assert!(parse_params(
+            [os("sdiff"), os("--tabsize=r2"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+        assert!(parse_params(
+            [os("sdiff"), os("--tabsize=-1"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+        assert!(parse_params(
+            [os("sdiff"), os("--tabsize=r2"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+        assert!(parse_params(
+            [
+                os("sdiff"),
+                os("--tabsize=92233720368547758088"),
+                os("foo"),
+                os("bar")
+            ]
+            .iter()
+            .cloned()
+            .peekable()
+        )
+        .is_err());
     }
 }

--- a/src/sdiff.rs
+++ b/src/sdiff.rs
@@ -5,7 +5,6 @@
 
 use regex::Regex;
 
-// use crate::params::parse_params;
 use crate::side_diff;
 use crate::utils;
 use std::env::ArgsOs;
@@ -227,17 +226,21 @@ mod tests {
         assert_eq!(
             Ok(Params {
                 executable: os("sdiff"),
-                from: os("foo"),
-                to: os("bar"),
+                from: os("-"),
+                to: os("-"),
                 ..Default::default()
             }),
-            parse_params(
-                [os("sdiff"), os("foo"), os("bar")]
-                    .iter()
-                    .cloned()
-                    .peekable()
-            )
+            parse_params([os("sdiff"), os("-"), os("-")].iter().cloned().peekable())
         );
+
+        assert!(parse_params(
+            [os("sdiff"), os("foo"), os("bar"), os("-"), os("-")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+
         for option in ["-t", "--expand-tabs"] {
             assert_eq!(
                 Ok(Params {
@@ -255,6 +258,39 @@ mod tests {
                 )
             );
         }
+
+        assert_eq!(
+            Ok(Params {
+                executable: os("sdiff"),
+                from: os("foo"),
+                to: os("bar"),
+                width: 10,
+                ..Default::default()
+            }),
+            parse_params(
+                [os("sdiff"), os("--width=10"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        );
+
+        assert!(parse_params(
+            [os("sdiff"), os("--width=0"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+
+        assert!(parse_params(
+            [os("sdiff"), os("--width=.1"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+
         assert_eq!(
             Ok(Params {
                 executable: os("sdiff"),
@@ -269,6 +305,7 @@ mod tests {
                     .peekable()
             )
         );
+
         assert_eq!(
             Ok(Params {
                 executable: os("sdiff"),
@@ -284,6 +321,15 @@ mod tests {
                     .peekable()
             )
         );
+
+        assert!(parse_params(
+            [os("sdiff"), os("--tabsize=0"), os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
+        )
+        .is_err());
+
         assert_eq!(
             Ok(Params {
                 executable: os("sdiff"),
@@ -299,6 +345,9 @@ mod tests {
                     .peekable()
             )
         );
+
+        assert!(parse_params([os("sdiff")].iter().cloned().peekable()).is_err());
+
         assert!(parse_params(
             [os("sdiff"), os("--tabsize"), os("foo"), os("bar")]
                 .iter()
@@ -306,6 +355,7 @@ mod tests {
                 .peekable()
         )
         .is_err());
+
         assert!(parse_params(
             [os("sdiff"), os("--tabsize="), os("foo"), os("bar")]
                 .iter()
@@ -313,6 +363,7 @@ mod tests {
                 .peekable()
         )
         .is_err());
+
         assert!(parse_params(
             [os("sdiff"), os("--tabsize=r2"), os("foo"), os("bar")]
                 .iter()
@@ -320,6 +371,7 @@ mod tests {
                 .peekable()
         )
         .is_err());
+
         assert!(parse_params(
             [os("sdiff"), os("--tabsize=-1"), os("foo"), os("bar")]
                 .iter()
@@ -327,6 +379,7 @@ mod tests {
                 .peekable()
         )
         .is_err());
+
         assert!(parse_params(
             [os("sdiff"), os("--tabsize=r2"), os("foo"), os("bar")]
                 .iter()
@@ -334,6 +387,7 @@ mod tests {
                 .peekable()
         )
         .is_err());
+
         assert!(parse_params(
             [
                 os("sdiff"),

--- a/src/sdiff.rs
+++ b/src/sdiff.rs
@@ -52,7 +52,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
     let tabsize_re = Regex::new(r"^--tabsize=(?<num>\d+)$").unwrap();
     let width_re = Regex::new(r"--width=(?P<long>\d+)$").unwrap();
 
-    while let Some(param) = opts.next() {
+    for param in opts.by_ref() {
         if param == "-" {
             if from.is_none() {
                 from = Some(param);
@@ -135,7 +135,10 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
     } else if let Some(param) = opts.next() {
         param
     } else {
-        return Err(format!("Err"));
+        return Err(format!(
+            "Usage: {} <from> <to>",
+            params.executable.to_string_lossy()
+        ));
     };
 
     params.to = if let Some(to) = to {
@@ -143,7 +146,10 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
     } else if let Some(param) = opts.next() {
         param
     } else {
-        return Err(format!("Err"));
+        return Err(format!(
+            "Usage: {} <from> <to>",
+            params.executable.to_string_lossy()
+        ));
     };
 
     Ok(params)

--- a/src/side_diff.rs
+++ b/src/side_diff.rs
@@ -8,8 +8,6 @@ use diff::Result;
 use std::{io::Write, vec};
 use unicode_width::UnicodeWidthStr;
 
-use crate::params::Params;
-
 const GUTTER_WIDTH_MIN: usize = 3;
 
 struct CharIter<'a> {
@@ -304,6 +302,13 @@ fn push_output<T: Write>(
     }
 
     Ok(())
+}
+
+#[derive(Default)]
+pub struct Params {
+    pub width: usize,
+    pub tabsize: usize,
+    pub expand_tabs: bool,
 }
 
 pub fn diff<T: Write>(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -153,6 +153,52 @@ mod tests {
         }
     }
 
+    mod read_file {
+        use super::*;
+        use tempfile::NamedTempFile;
+
+        #[test]
+        fn read_two_valid_files() {
+            let content1 = "content-1";
+            let content2 = "content-2";
+
+            let mut from_file = NamedTempFile::new().unwrap();
+            let mut to_file = NamedTempFile::new().unwrap();
+
+            from_file.write_all(content1.as_bytes()).unwrap();
+            to_file.write_all(content2.as_bytes()).unwrap();
+
+            let from_path = OsString::from(from_file.path());
+            let to_path = OsString::from(to_file.path());
+
+            let res = read_both_files(&from_path, &to_path);
+
+            assert!(res.is_ok());
+            let (from_content, to_content) = res.unwrap();
+            assert_eq!(from_content, content1.as_bytes());
+            assert_eq!(to_content, content2.as_bytes());
+        }
+
+        #[test]
+        fn read_not_exist_file() {
+            let mut file = NamedTempFile::new().unwrap();
+            file.write_all(b"valid-file").unwrap();
+            let exist_file_path = OsString::from(file.path());
+
+            let non_exist_file_path = OsString::from("non-exist-file");
+
+            let res = read_both_files(&non_exist_file_path, &exist_file_path);
+            assert!(res.is_err());
+            let (err_path, _) = res.unwrap_err();
+            assert_eq!(err_path, non_exist_file_path);
+
+            let res = read_both_files(&exist_file_path, &non_exist_file_path);
+            assert!(res.is_err());
+            let (err_path, _) = res.unwrap_err();
+            assert_eq!(err_path, non_exist_file_path);
+        }
+    }
+
     mod write_line {
         use super::*;
         use pretty_assertions::assert_eq;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -57,7 +57,7 @@ mod common {
         #[cfg(windows)]
         let error_message = "The system cannot find the file specified.";
 
-        for subcmd in ["diff", "cmp"] {
+        for subcmd in ["diff", "cmp", "sdiff"] {
             let mut cmd = cargo_bin_cmd!("diffutils");
             cmd.arg(subcmd);
             cmd.arg(&nopath).arg(file.path());
@@ -884,6 +884,30 @@ mod cmp {
             .code(predicate::eq(1))
             .failure()
             .stdout(predicate::str::ends_with(" differ: byte 24577, line 4\n"));
+
+        Ok(())
+    }
+}
+
+mod sdiff {
+    use super::*;
+
+    #[test]
+    fn differences() -> Result<(), Box<dyn std::error::Error>> {
+        let mut file1 = NamedTempFile::new()?;
+        file1.write_all("foo\n".as_bytes())?;
+
+        let mut file2 = NamedTempFile::new()?;
+        file2.write_all("bar\n".as_bytes())?;
+
+        let mut cmd = cargo_bin_cmd!("diffutils");
+        cmd.arg("diff");
+        cmd.arg(file1.path()).arg(file2.path());
+
+        cmd.assert()
+            .code(predicate::eq(1))
+            .failure()
+            .stdout(predicate::str::is_empty().not());
 
         Ok(())
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -84,13 +84,13 @@ mod common {
         let mut cmd = cargo_bin_cmd!("diffutils");
         cmd.arg("diff");
         cmd.arg(&nopath).arg(&nopath);
-        cmd.assert().code(predicate::eq(2)).failure().stderr(
-            predicate::str::contains(format!(
+        cmd.assert()
+            .code(predicate::eq(2))
+            .failure()
+            .stderr(predicate::str::contains(format!(
                 ": {}: {error_message}\n",
                 &nopath.as_os_str().to_string_lossy()
-            ))
-            .count(2),
-        );
+            )));
 
         Ok(())
     }


### PR DESCRIPTION
Initial implementation of `sdiff`

So far, just reuse `side_diff` implementation to just show a side by side diff (same as `diff -y`)

Currently supports arguments: `from_file`, `to_file`, `expand_tabs`, `tabsize`, `width` since it is already was implemented for the `diff` and used by `side_diff`. The rest and interactive mode is supposed to be added in following PRs.

Relates to: #16 