### PR TITLE
tests: fix "old" names in generated patch files

### DIFF
--- a/fuzz/fuzz_targets/fuzz_patch.rs
+++ b/fuzz/fuzz_targets/fuzz_patch.rs
@@ -22,15 +22,16 @@ fuzz_target!(|x: (Vec<u8>, Vec<u8>, u8)| {
         return
     }*/
     fs::create_dir_all("target").unwrap();
+    let patched = "target/fuzz.file";
     let diff = unified_diff::diff(
         &from,
         &to,
         &Params {
-            from: "a/fuzz.file".into(),
-            to: "target/fuzz.file".into(),
+            from: patched.into(),
+            to: patched.into(),
             context_count: context as usize,
             ..Default::default()
-        }
+        },
     );
     File::create("target/fuzz.file.original")
         .unwrap()

--- a/src/context_diff.rs
+++ b/src/context_diff.rs
@@ -429,12 +429,13 @@ mod tests {
                                 }
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let patched = &format!("{target}/alef");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alef".into(),
-                                        to: (&format!("{target}/alef")).into(),
+                                        from: patched.into(),
+                                        to: patched.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },
@@ -510,12 +511,13 @@ mod tests {
                                 }
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let patched = &format!("{target}/alef_");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alef_".into(),
-                                        to: (&format!("{target}/alef_")).into(),
+                                        from: patched.into(),
+                                        to: patched.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },
@@ -594,12 +596,13 @@ mod tests {
                                 };
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let patched = &format!("{target}/alefx");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alefx".into(),
-                                        to: (&format!("{target}/alefx")).into(),
+                                        from: patched.into(),
+                                        to: patched.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },
@@ -681,12 +684,13 @@ mod tests {
                                 }
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let alefr_path = &format!("{target}/alefr");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alefr".into(),
-                                        to: (&format!("{target}/alefr")).into(),
+                                        from: alefr_path.into(),
+                                        to: alefr_path.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -456,12 +456,13 @@ mod tests {
                                 }
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let patched = &format!("{target}/alef");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alef".into(),
-                                        to: (&format!("{target}/alef")).into(),
+                                        from: patched.into(),
+                                        to: patched.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },
@@ -572,12 +573,13 @@ mod tests {
                                     }
                                     // This test diff is intentionally reversed.
                                     // We want it to turn the alef into bet.
+                                    let patched = &format!("{target}/alefn");
                                     let diff = diff(
                                         &alef,
                                         &bet,
                                         &Params {
-                                            from: "a/alefn".into(),
-                                            to: (&format!("{target}/alefn")).into(),
+                                            from: patched.into(),
+                                            to: patched.into(),
                                             context_count: 2,
                                             ..Default::default()
                                         },
@@ -668,12 +670,13 @@ mod tests {
                                     }
                                     // This test diff is intentionally reversed.
                                     // We want it to turn the alef into bet.
+                                    let patched = &format!("{target}/alef_");
                                     let diff = diff(
                                         &alef,
                                         &bet,
                                         &Params {
-                                            from: "a/alef_".into(),
-                                            to: (&format!("{target}/alef_")).into(),
+                                            from: patched.into(),
+                                            to: patched.into(),
                                             context_count: 2,
                                             ..Default::default()
                                         },
@@ -749,12 +752,13 @@ mod tests {
                                 }
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let patched = &format!("{target}/alefx");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alefx".into(),
-                                        to: (&format!("{target}/alefx")).into(),
+                                        from: patched.into(),
+                                        to: patched.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },
@@ -835,12 +839,13 @@ mod tests {
                                 }
                                 // This test diff is intentionally reversed.
                                 // We want it to turn the alef into bet.
+                                let patched = &format!("{target}/alefr");
                                 let diff = diff(
                                     &alef,
                                     &bet,
                                     &Params {
-                                        from: "a/alefr".into(),
-                                        to: (&format!("{target}/alefr")).into(),
+                                        from: patched.into(),
+                                        to: patched.into(),
                                         context_count: 2,
                                         ..Default::default()
                                     },


### PR DESCRIPTION
Fixes #223. Very simple reproduction

```
cd diffutils
mkdir a
touch a/alef  a/alefn  a/alef_  a/alefx  a/alefr  a/fuzz.file
cargo test
```
 => fail

https://www.gnu.org/software/diffutils/manual/html_node/Multiple-Patches.html states that the "old" file name has precedence over the "new" filename.

I hit this problem because some other (and unfortunately: unknown for now) test issue left bogus `a/alef*` file(s) behind in my workspace. I didn't bother cleaning them up because I assumed some test would keep recreating them and that cost me a lot of time.

This issue seems to have existed since the very first commit. Interestingly, there as a previous attempt in 2024 to fix this in commit a3a372ff362992df3 ! So I was apparently not the only affected. BUT that fix was immediately reverted by commit ba7cb0aef9dcdeb19 in the same PR. Admittedly, that fix seemed somewhat off-topic in https://github.com/uutils/diffutils/pull/33. So here it is again.