### PR TITLE
CI: remove echo "/opt/homebrew/opt/gpatch/libexec/gnubin" >> "$GITHUB_PATH"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
         if: runner.os == 'macOS'
         run: |
           brew install gpatch
-          echo "/opt/homebrew/opt/gpatch/libexec/gnubin" >> "$GITHUB_PATH"
       - name: set up PATH on Windows
         # Needed to use GNU's patch.exe instead of Strawberry Perl patch
         if: runner.os == 'Windows'
@@ -85,7 +84,6 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew install gpatch
-        echo "/opt/homebrew/opt/gpatch/libexec/gnubin" >> "$GITHUB_PATH"
     - name: set up PATH on Windows
       # Needed to use GNU's patch.exe instead of Strawberry Perl patch
       if: runner.os == 'Windows'


### PR DESCRIPTION
This is not needed now that tests automatically look for `gpatch` on mac since commit 1254f146f8f1 ("tests: validate "patch" and "ed" commands once, print meaningful messages (#226)")

The fewer PATH changes, the better.

cc: @oSoMoN 