### PR TITLE
diffutils: fix panic on non-UTF-8 argument ending in --width=N

### DIFF
--- a/src/params.rs
+++ b/src/params.rs
@@ -60,7 +60,7 @@ pub fn parse_params<I: Iterator<Item = OsString>>(mut opts: Peekable<I>) -> Resu
     let mut format = None;
     let mut context = None;
     let tabsize_re = Regex::new(r"^--tabsize=(?<num>\d+)$").unwrap();
-    let width_re = Regex::new(r"--width=(?P<long>\d+)$").unwrap();
+    let width_re = Regex::new(r"^--width=(?P<long>\d+)$").unwrap();
     while let Some(param) = opts.next() {
         let next_param = opts.peek();
         if param == "--" {
@@ -809,6 +809,40 @@ mod tests {
             .iter()
             .cloned()
             .peekable()
+        )
+        .is_err());
+    }
+    #[test]
+    fn width() {
+        assert_eq!(
+            Ok(Params {
+                executable: os("diff"),
+                from: os("foo"),
+                to: os("bar"),
+                width: 100,
+                ..Default::default()
+            }),
+            parse_params(
+                [os("diff"), os("--width=100"), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable()
+            )
+        );
+    }
+    #[cfg(unix)]
+    #[test]
+    fn width_non_utf8_is_not_an_option() {
+        use std::os::unix::ffi::OsStringExt;
+        // A non-UTF-8 argument whose lossy form ends in `--width=N` must be
+        // treated as an operand, not parsed as the width option (which used to
+        // panic in `into_string().unwrap()`).
+        let bad = OsString::from_vec(b"\xff--width=5".to_vec());
+        assert!(parse_params(
+            [os("diff"), bad, os("foo"), os("bar")]
+                .iter()
+                .cloned()
+                .peekable()
         )
         .is_err());
     }


### PR DESCRIPTION
`diff` panicked with exit 101 on a non-UTF-8 argument whose lossy form ends in `--width=N`, e.g. `diff $'\xff--width=5' A B`. The `--width` regex was missing the leading `^` anchor that `--tabsize` already has, so the lossy (`U+FFFD`) form matched and the following `into_string().unwrap()` then failed on the real bytes.

Anchoring the regex (`^--width=...$`, matching `tabsize_re`) makes such an argument fall through to the operand path instead of being parsed as a width option, so it no longer panics. As a side effect `diff xyz--width=5` is now also treated as a filename rather than silently accepting a width.

Added a `width` test and a `#[cfg(unix)]` regression test for the non-UTF-8 case.

Fixes #247.
