### PR TITLE
clippy: fix warnings

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -706,8 +706,8 @@ fn report_difference(
     };
     print!(
         "{} {} differ: {term} {}, line {}",
-        &params.from.to_string_lossy(),
-        &params.to.to_string_lossy(),
+        params.from.to_string_lossy(),
+        params.to.to_string_lossy(),
         at_byte,
         at_line
     );

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -477,7 +477,7 @@ pub fn main(opts: Peekable<ArgsOs>) -> ExitCode {
 
 #[inline]
 fn format_octal(byte: u8, buf: &mut [u8; 3]) -> &str {
-    *buf = [b' ', b' ', b'0'];
+    *buf = *b"  0";
 
     let mut num = byte;
     let mut idx = 2; // Start at the last position in the buffer


### PR DESCRIPTION
This PR fixes warnings from the [byte_char_slices](https://rust-lang.github.io/rust-clippy/master/index.html#byte_char_slices) and [useless_borrows_in_formatting](https://rust-lang.github.io/rust-clippy/master/index.html#useless_borrows_in_formatting) lints.