### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Fig
 Cherry
 EOF
 
-$ cargo run -- -u fruits_old.txt fruits_new.txt
+$ cargo run -- diff -u fruits_old.txt fruits_new.txt
     Finished dev [unoptimized + debuginfo] target(s) in 0.00s
      Running `target/debug/diffutils -u fruits_old.txt fruits_new.txt`
 --- fruits_old.txt


### PR DESCRIPTION
I checked the commit when the example was written and it worked then, but the diffutils have changed since then and the example no longer works because it expects the utility name to be supplied.