### PR TITLE
fix: panics on redirect to /dev/full

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -3,8 +3,8 @@
 // For the full copyright and license information, please view the LICENSE-*
 // files that was distributed with this source code.
 
-use crate::utils::format_failure_to_read_input_file;
 use crate::safe_println;
+use crate::utils::format_failure_to_read_input_file;
 use std::env::{self, ArgsOs};
 use std::ffi::OsString;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -4,6 +4,7 @@
 // files that was distributed with this source code.
 
 use crate::utils::format_failure_to_read_input_file;
+use crate::safe_println;
 use std::env::{self, ArgsOs};
 use std::ffi::OsString;
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
@@ -721,7 +722,7 @@ fn report_difference(
             format_visible_byte(to_byte)
         );
     }
-    println!();
+    safe_println!();
 }
 
 #[cfg(test)]

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -91,7 +91,7 @@ pub fn main(opts: Peekable<ArgsOs>) -> ExitCode {
             params.to.to_string_lossy()
         );
     } else {
-        io::stdout().write_all(&result).unwrap();
+        let _ = io::stdout().write_all(&result);
     }
     if result.is_empty() {
         maybe_report_identical_files();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -23,3 +23,15 @@ macro_rules! assert_diff_eq {
         assert_eq!(actual, $expected);
     }};
 }
+
+/// A safe version of println!() that does not panic if stdout is redirected to /dev/full
+#[macro_export]
+macro_rules! safe_println {
+    () => {
+        let _ = ::std::io::Write::write_all(&mut ::std::io::stdout(), b"\n");
+    };
+    ($($arg:tt)*) => {
+        let _ = ::std::io::Write::write_fmt(&mut ::std::io::stdout(), format_args!($($arg)*))
+            .and_then(|_| ::std::io::Write::write_all(&mut ::std::io::stdout(), b"\n"));
+    };
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,10 +40,10 @@ fn name(binary_path: &Path) -> &OsStr {
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 fn usage(name: &str) {
-    println!("{name} {VERSION} (multi-call binary)\n");
-    println!("Usage: {name} [function [arguments...]]\n");
-    println!("Currently defined functions:\n");
-    println!("    cmp, diff\n");
+    safe_println!("{name} {VERSION} (multi-call binary)\n");
+    safe_println!("Usage: {name} [function [arguments...]]\n");
+    safe_println!("Currently defined functions:\n");
+    safe_println!("    cmp, diff\n");
 }
 
 fn second_arg_error(name: &OsStr) -> ! {


### PR DESCRIPTION
This fixes several panics that would occur when the stdout was redirected to /dev/full. This also introduces a new macro for this purpose, named `safe_println!()`, that does not panic in this situation, which can presumably be reused elsewhere this issue may reoccur in the future.