### PR TITLE
cmp: don't reopen /dev/null on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "regex",
+ "rustix",
  "same-file",
  "tempfile",
  "unicode-width",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ chrono = "0.4.38"
 diff = "0.1.13"
 itoa = "1.0.11"
 regex = "1.10.4"
+rustix = { version = "1.1.4", features = ["fs"] }
 same-file = "1.0.6"
 unicode-width = "0.2.0"
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,8 +95,19 @@ dependencies = [
  "diff",
  "itoa",
  "regex",
+ "rustix",
  "same-file",
  "unicode-width",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -178,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,6 +279,19 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"

--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -11,12 +11,6 @@ use std::iter::Peekable;
 use std::process::ExitCode;
 use std::{cmp, fs, io};
 
-#[cfg(unix)]
-use std::os::fd::{AsRawFd, FromRawFd};
-
-#[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
-
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::MetadataExt;
 
@@ -43,8 +37,22 @@ fn usage_string(executable: &str) -> String {
     format!("Usage: {executable} <from> <to>")
 }
 
-#[cfg(unix)]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn is_stdout_dev_null() -> bool {
+    use rustix::fs;
+    let stdout = io::stdout();
+    let Ok(stat) = fs::fstat(stdout) else {
+        return false;
+    };
+    let dev = stat.st_rdev;
+    fs::major(dev) == 1 && fs::minor(dev) == 3
+}
+
+#[cfg(unix)]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn is_stdout_dev_null() -> bool {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::MetadataExt;
     let Ok(dev_null) = fs::metadata("/dev/null") else {
         return false;
     };


### PR DESCRIPTION
Don't reopen 2nd `/dev/null` at `fn is_stdout_dev_null` on Linux.