### PR TITLE
diff: don't panic on an oversized context count

### DIFF
--- a/src/context_diff.rs
+++ b/src/context_diff.rs
@@ -53,6 +53,11 @@ fn make_diff(
 ) -> Vec<Mismatch> {
     let mut line_number_expected = 1;
     let mut line_number_actual = 1;
+    // `context_size` comes straight from the command line and may be enormous.
+    // Neither file can have more lines than it has bytes, so a larger request
+    // already means "the whole file"; clamping keeps the arithmetic below in
+    // range and the preallocation proportional to the input.
+    let context_size = context_size.min(expected.len() + actual.len() + 1);
     let mut context_queue: VecDeque<&[u8]> = VecDeque::with_capacity(context_size);
     let mut lines_since_mismatch = context_size + 1;
     let mut results = Vec::new();

--- a/src/params.rs
+++ b/src/params.rs
@@ -276,7 +276,9 @@ fn match_context_diff_params(
             .or(captures.name("num3"));
         if let Some(numvalue) = num {
             if !numvalue.as_str().is_empty() {
-                context_count = Some(numvalue.as_str().parse::<usize>().unwrap());
+                // GNU accepts a count larger than the machine can represent and
+                // clamps it, so saturate rather than panicking on overflow.
+                context_count = Some(numvalue.as_str().parse::<usize>().unwrap_or(usize::MAX));
             }
         }
         if param == "-C" {
@@ -320,7 +322,9 @@ fn match_unified_diff_params(
             .or(captures.name("num3"));
         if let Some(numvalue) = num {
             if !numvalue.as_str().is_empty() {
-                context_count = Some(numvalue.as_str().parse::<usize>().unwrap());
+                // GNU accepts a count larger than the machine can represent and
+                // clamps it, so saturate rather than panicking on overflow.
+                context_count = Some(numvalue.as_str().parse::<usize>().unwrap_or(usize::MAX));
             }
         }
         if param == "-U" {
@@ -914,6 +918,26 @@ mod tests {
                     .peekable()
             )
             .is_err());
+        }
+    }
+
+    #[test]
+    fn oversized_context_count_saturates() {
+        // A digit run too large for usize must clamp rather than panic.
+        for arg in [
+            "-u99999999999999999999",
+            "-c99999999999999999999",
+            "--unified=99999999999999999999",
+            "--context=99999999999999999999",
+        ] {
+            let params = parse_params(
+                [os("diff"), os(arg), os("foo"), os("bar")]
+                    .iter()
+                    .cloned()
+                    .peekable(),
+            )
+            .unwrap();
+            assert_eq!(params.context_count, usize::MAX);
         }
     }
 }

--- a/src/unified_diff.rs
+++ b/src/unified_diff.rs
@@ -44,6 +44,11 @@ fn make_diff(
 ) -> Vec<Mismatch> {
     let mut line_number_expected = 1;
     let mut line_number_actual = 1;
+    // `context_size` comes straight from the command line and may be enormous.
+    // Neither file can have more lines than it has bytes, so a larger request
+    // already means "the whole file"; clamping keeps the arithmetic below in
+    // range and the preallocation proportional to the input.
+    let context_size = context_size.min(expected.len() + actual.len() + 1);
     let mut context_queue: VecDeque<&[u8]> = VecDeque::with_capacity(context_size);
     let mut lines_since_mismatch = context_size + 1;
     let mut results = Vec::new();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -225,6 +225,35 @@ mod diff {
     }
 
     #[test]
+    fn oversized_context_count() -> Result<(), Box<dyn std::error::Error>> {
+        let mut file1 = NamedTempFile::new()?;
+        file1.write_all("a\nb\nc\n".as_bytes())?;
+        let mut file2 = NamedTempFile::new()?;
+        file2.write_all("a\nX\nc\n".as_bytes())?;
+
+        // A context count past usize, and one that fits but would overflow the
+        // queue's capacity in bytes. Both used to abort.
+        for option in [
+            "-u99999999999999999999",
+            "-c99999999999999999999",
+            "--unified=99999999999999999999",
+            "--context=99999999999999999999",
+            "-U600000000000000000",
+            "-C600000000000000000",
+        ] {
+            let mut cmd = cargo_bin_cmd!("diffutils");
+            cmd.arg("diff")
+                .arg(option)
+                .arg(file1.path())
+                .arg(file2.path());
+            cmd.assert()
+                .code(predicate::eq(1))
+                .stdout(predicate::str::contains("X"));
+        }
+        Ok(())
+    }
+
+    #[test]
     fn read_from_stdin() -> Result<(), Box<dyn std::error::Error>> {
         let mut file1 = NamedTempFile::new()?;
         file1.write_all("foo\n".as_bytes())?;


### PR DESCRIPTION
Fixes #245.

Both panics in the issue come from the context count being used unchecked:

- `-u99999999999999999999` and friends reach `numvalue.as_str().parse::<usize>().unwrap()` in `params.rs`, and `PosOverflow` aborts the process.
- A count that does fit in usize but is large enough that `N * 16 > isize::MAX` gets past the parser and aborts in `VecDeque::with_capacity` instead, which is the second case @leeewee added in the comments.

The parse now saturates, and `make_diff` clamps `context_size` to the combined length of the two inputs. Neither file can have more lines than it has bytes, so a request above that already meant "the whole file" — the clamp only removes values that were never reachable, and it keeps both the preallocation and the `context_size + 1` arithmetic below it in range. That covers the unified and context paths in one place rather than guarding each site.

All six affected spellings now produce the same output as a plain `-u`/`-c` run and exit 1.

Tests: a unit test in `params.rs` for the saturating parse, and an integration test running each spelling end to end.

One thing I left alone: the separate-argument forms (`-C 99999999999999999999`) already return `invalid context length` rather than panicking. GNU accepts those, so the behaviour still differs, but since it is not a crash I did not want to fold a compatibility change into this fix. Happy to do it separately if you want them aligned.