### PR TITLE
cmp: use checked subtraction for the verbose offset padding

### DIFF
--- a/src/cmp.rs
+++ b/src/cmp.rs
@@ -607,7 +607,7 @@ fn format_verbose_difference(
     } else {
         // "{:>width$} {:>3o} {:>3o}"
         let at_byte_str = at_byte_buf.format(at_byte);
-        let at_byte_padding = offset_width - at_byte_str.len();
+        let at_byte_padding = offset_width.saturating_sub(at_byte_str.len());
 
         for _ in 0..at_byte_padding {
             output.push(b' ')

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -348,6 +348,26 @@ mod diff {
 mod cmp {
     use super::*;
 
+    // A file whose metadata length is 0 but which still yields bytes (/dev/zero)
+    // collapses the offset column to two characters, so the padding subtraction
+    // underflowed once the running offset reached three digits.
+    #[test]
+    #[cfg(unix)]
+    fn cmp_verbose_zero_length_metadata() -> Result<(), Box<dyn std::error::Error>> {
+        let mut file = NamedTempFile::new()?;
+        file.write_all(&[0xffu8; 150])?;
+
+        let mut cmd = cargo_bin_cmd!("diffutils");
+        cmd.arg("cmp")
+            .arg("--verbose")
+            .arg("/dev/zero")
+            .arg(file.path());
+        cmd.assert()
+            .code(predicate::eq(1))
+            .stdout(predicate::str::contains("150   0 377"));
+        Ok(())
+    }
+
     #[test]
     fn cmp_incompatible_params() -> Result<(), Box<dyn std::error::Error>> {
         let mut cmd = cargo_bin_cmd!("diffutils");


### PR DESCRIPTION
Fixes #265.

The `--print-bytes` branch of `format_verbose_difference` already pads with `saturating_sub`; the `--verbose` branch a few lines down uses a plain `-`. Since `offset_width` comes from the smaller file's *metadata* length, a file that reports length 0 but still yields bytes collapses it to 2, and the subtraction underflows as soon as the running offset reaches three digits.

```console
$ printf '\377%.0s' {1..150} > nz
$ cmp --verbose /dev/zero nz
```

Before, that stops after byte 99 (abort under overflow-checks, a huge padding loop otherwise). After, all 150 lines print and it exits 1.

Made the two branches match rather than adding a separate guard.

Worth flagging since the issue shows GNU's output: the column is still narrower than GNU's here, because `offset_width` is derived from a metadata length that is 0 for this kind of file. That is the same root input, but it is a formatting difference rather than a crash, so I have left it out of this change.

Tests: an integration test covering the case, gated to unix for `/dev/zero`.