### PR TITLE
diff: exit 141 on a closed output pipe instead of panicking

### DIFF
--- a/src/diff.rs
+++ b/src/diff.rs
@@ -4,7 +4,7 @@
 // files that was distributed with this source code.
 
 use crate::params::{parse_params, Format};
-use crate::utils::report_failure_to_read_input_file;
+use crate::utils::{exit_on_broken_pipe_or_panic, report_failure_to_read_input_file};
 use crate::{context_diff, ed_diff, normal_diff, side_diff, unified_diff};
 use std::env::ArgsOs;
 use std::ffi::OsString;
@@ -90,8 +90,8 @@ pub fn main(opts: Peekable<ArgsOs>) -> ExitCode {
             params.from.to_string_lossy(),
             params.to.to_string_lossy()
         );
-    } else {
-        io::stdout().write_all(&result).unwrap();
+    } else if let Err(e) = io::stdout().write_all(&result) {
+        exit_on_broken_pipe_or_panic(e);
     }
     if result.is_empty() {
         maybe_report_identical_files();

--- a/src/side_diff.rs
+++ b/src/side_diff.rs
@@ -9,6 +9,7 @@ use std::{io::Write, vec};
 use unicode_width::UnicodeWidthStr;
 
 use crate::params::Params;
+use crate::utils::exit_on_broken_pipe_or_panic;
 
 const GUTTER_WIDTH_MIN: usize = 3;
 
@@ -350,10 +351,20 @@ pub fn diff<T: Write>(
     */
     for result in diff::slice(&left_lines, &right_lines) {
         match result {
-            Result::Left(left_ln) => push_output(left_ln, b"", b'<', output, &config).unwrap(),
-            Result::Right(right_ln) => push_output(b"", right_ln, b'>', output, &config).unwrap(),
+            Result::Left(left_ln) => {
+                if let Err(e) = push_output(left_ln, b"", b'<', output, &config) {
+                    exit_on_broken_pipe_or_panic(e);
+                }
+            }
+            Result::Right(right_ln) => {
+                if let Err(e) = push_output(b"", right_ln, b'>', output, &config) {
+                    exit_on_broken_pipe_or_panic(e);
+                }
+            }
             Result::Both(left_ln, right_ln) => {
-                push_output(left_ln, right_ln, b' ', output, &config).unwrap()
+                if let Err(e) = push_output(left_ln, right_ln, b' ', output, &config) {
+                    exit_on_broken_pipe_or_panic(e);
+                }
             }
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,6 +7,17 @@ use regex::Regex;
 use std::{ffi::OsString, io::Write};
 use unicode_width::UnicodeWidthStr;
 
+/// Handle a write error to stdout: if the pipe was closed by the reader
+/// (e.g. `diff big1 big2 | head`), exit quietly like GNU does under
+/// `SIGPIPE` (128 + 13 = 141) instead of panicking with a core dump.
+/// Any other write error is a genuine bug, so it still panics.
+pub fn exit_on_broken_pipe_or_panic(e: std::io::Error) -> ! {
+    if e.kind() == std::io::ErrorKind::BrokenPipe {
+        std::process::exit(141);
+    }
+    panic!("{e}");
+}
+
 /// Replace tabs by spaces in the input line.
 /// Correctly handle multi-bytes characters.
 /// This assumes that line does not contain any line breaks (if it does, the result is undefined).


### PR DESCRIPTION
## Summary

`diff`'s output write is a bare `.unwrap()` (normal/context/unified/ed path in `src/diff.rs:94`, side-by-side path in `src/side_diff.rs`), so when the reader closes the pipe early (`diff big1 big2 | head`) the `BrokenPipe` error is unwrapped and the process panics/aborts (exit 134) instead of dying quietly to `SIGPIPE` like GNU (exit 141).

## Fix

Added `exit_on_broken_pipe_or_panic` in `src/utils.rs`: on `ErrorKind::BrokenPipe` it exits with 141 (matching GNU); any other write error still panics, since that would be a genuine bug. Wired it into both write sites.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 21 passed
- [x] `cargo fmt -- --check` / `cargo clippy --all-targets` — clean (pre-existing warnings in unrelated test code untouched)
- [x] Manually reproduced with `diff big1 big2 | head -1` — before: panic, exit 134; after: exit 141
- [x] Same for `diff -y big1 big2 | head -1`

Fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)